### PR TITLE
Move to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,31 @@
+[settings.python]
+uv_venv_auto = true
+
+[tools]
+python = "3.13.7"
+uv = "0.8.13"
+ruff = "0.12.10"
+bun = "1.2.21"
+node = "24.6.0"
+
+[tasks.install]
+description = "Install dependencies"
+alias = "i"
+run = "uv sync --all-groups"
+
+[tasks.export]
+description = "Export deps to requirements.txt"
+run = "uv export --format requirements-txt --no-hashes --no-header --no-dev --no-annotate --output-file requirements.txt"
+
+[tasks.fix]
+description = "Lint & format (fix by default)"
+alias = "f"
+run = [
+    "uv run ruff format . --config pyproject.toml",
+    "uv run ruff check --fix --unsafe-fixes . --config pyproject.toml",
+]
+
+[tasks.mypy]
+description = "Type check with mypy"
+alias = "m"
+run = "uv run mypy megaloader --config-file pyproject.toml"

--- a/mise.toml
+++ b/mise.toml
@@ -28,4 +28,4 @@ run = [
 [tasks.mypy]
 description = "Type check with mypy"
 alias = "m"
-run = "uv run mypy megaloader --config-file pyproject.toml"
+run = "uv run mypy excel_analysis --config-file pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ start = "excel_analysis.stock_processing:main"
 extend-exclude = ["web"]
 fix = true
 line-length = 88
-target-version = "py312"
+target-version = "py313"
 
 [tool.ruff.lint]
 extend-select = [
@@ -67,6 +67,6 @@ enable_error_code = [
     "truthy-bool",
 ]
 
-[[tool.mypy.overrides]]
-module = ["requests.*"]
-ignore_missing_imports = true
+# [[tool.mypy.overrides]]
+# module = ["requests.*"]
+# ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,26 +1,71 @@
-[tool.poetry]
+[project]
 name = "excel-analysis"
 version = "0.8.0"
 description = ""
-authors = ["David Duran <dadch1404@gmail.com>"]
 readme = "README.md"
-packages = [{include = "excel_analysis"}]
+authors = ["David Duran <dadch1404@gmail.com>"]
+dependencies = [
+    "datareader>=0.0.9",
+    "pandas-datareader>=0.10.0",
+    "yfinance>=0.2.26",
+    "scikit-learn>=1.3.0",
+    "openpyxl>=3.1.2",
+    "pandas>=2.0.3",
+]
 
-[tool.poetry.dependencies]
-python = "^3.10"
-datareader = "^0.0.9"
-pandas-datareader = "^0.10.0"
-yfinance = "^0.2.26"
-scikit-learn = "^1.3.0"
-openpyxl = "^3.1.2"
-pytest = "^7.4.0"
-pandas = "^2.0.3"
-pylint = "^3.0.2"
-pre-commit = "^3.6.0"
+[dependency-groups]
+dev = [
+    "mypy>=1.17.1",
+    "pytest>=7.4.0",
+    "pylint>=3.0.2",
+    "pre-commit>=3.6.0",
+]
 
 [tool.poetry.scripts]
 start = "excel_analysis.stock_processing:main"
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.ruff]
+extend-exclude = ["web"]
+fix = true
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+extend-select = [
+    "B",
+    "C4",
+    "ERA",
+    "I",
+    "N",
+    "PIE",
+    "PGH",
+    "RUF",
+    "SIM",
+    "T20",
+    "TC",
+    "TID",
+    "UP",
+]
+extend-safe-fixes = ["TC"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.lint.isort]
+force-single-line = false
+lines-between-types = 1
+lines-after-imports = 2
+
+[tool.mypy]
+files = "excel_analysis"
+namespace_packages = true
+explicit_package_bases = true
+strict = true
+enable_error_code = [
+    "ignore-without-code",
+    "redundant-expr",
+    "truthy-bool",
+]
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
     "pre-commit>=3.6.0",
 ]
 
-[tool.poetry.scripts]
+[project.scripts]
 start = "excel_analysis.stock_processing:main"
 
 [tool.ruff]
@@ -68,4 +68,5 @@ enable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
+module = ["requests.*"]
 ignore_missing_imports = true


### PR DESCRIPTION
This pull request introduces significant improvements to project configuration and dependency management by migrating from Poetry to PEP 621/pyproject.toml standards, introducing new development tooling, and adding a mise.toml file for unified tool and task management. The changes modernize the setup, streamline dependency handling, and enhance development workflows.

* Migrated from Poetry-specific configuration to PEP 621-compliant [project] table in pyproject.toml, updating dependencies and moving development dependencies into a [dependency-groups] section.
* Removed the Poetry build backend and requirements, aligning with modern Python packaging standards.

Tooling and automation:
* Added a mise.toml file to manage Python, Node, and related tools' versions, and defined tasks for installing dependencies, exporting requirements, linting, formatting, and type checking.

Linting and type checking configuration:
* Introduced and configured ruff for linting and formatting, and mypy for type checking, with detailed settings in pyproject.toml to enforce code quality and style.